### PR TITLE
Merge development

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ source "https://rubygems.org"
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-gem "jekyll", "~> 4.2.1"
+gem "jekyll", "~> 4.2.2"
 
 # If you want to use GitHub Pages, remove the "gem "jekyll"" above and
 # uncomment the line below. To upgrade, run `bundle update github-pages`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       jekyll (>= 3.8, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.3.2)
+    kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
@@ -57,13 +57,13 @@ GEM
     mini_portile2 (2.8.0)
     neat (4.0.0)
       thor (~> 0.19)
-    nokogiri (1.13.3)
+    nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.22.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (4.0.6)
+    public_suffix (4.0.7)
     racc (1.6.0)
     rainbow (3.1.1)
     rb-fsevent (0.11.1)
@@ -93,7 +93,7 @@ PLATFORMS
 
 DEPENDENCIES
   html-proofer (~> 3.19.3)
-  jekyll (~> 4.2.1)
+  jekyll (~> 4.2.2)
   jekyll-seo-tag (~> 2.1)
   neat (~> 4.0.0)
   tzinfo (~> 1.2.0)
@@ -101,4 +101,4 @@ DEPENDENCIES
   wdm (~> 0.1.0)
 
 BUNDLED WITH
-   2.3.10
+   2.3.13


### PR DESCRIPTION
Update jekyll from 4.2.1 to 4.2.2 and bundle with bundler 2.3.13.

Merged `base` into `development` to align the two branches after recent commits directly to `base.`