### PR TITLE
Add RAC Accessibility Statement

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,11 +14,12 @@
       <p>Monday-Friday<br/>
          10:00 a.m. to 5:00 p.m.<br/>
          <a href={{"/collections/access-and-request-materials/" | relative_url }}>By appointment only.</a></p>
-      <a href={{"/collections/access-and-request-materials/holiday-schedule/" | relative_url }}>See holiday schedule</a>
+      <p><a href={{"/collections/access-and-request-materials/holiday-schedule/" | relative_url }}>See holiday schedule</a></p>
     </div>
     <div class="footer__section social">
       {% include social-icons.html %}
       <p>
+        <a class="policy-link" href={{"/about-us/accessibility/" | relative_url }}>Accessibility Statement</a>
         <a class="policy-link" href={{"/about-us/privacy-policy/" | relative_url }}>Privacy Policy</a>
         <a class="policy-link" href="https://docs.rockarch.org">RAC Policies</a>
       </p>

--- a/_sass/rac/_buttons.scss
+++ b/_sass/rac/_buttons.scss
@@ -14,6 +14,7 @@
   color: $pure-white;
   background: $deep-navy;
   opacity: 0.8;
+  text-decoration: none;
   transition: $transition-default;
   &:after {
         content: '\00a0>';
@@ -23,6 +24,7 @@
     cursor:pointer;
     transition: $transition-default;
     color: $pure-white;
+    text-decoration: underline;
   }
   @media screen and (min-width: $break-md) {
     padding: 20px;
@@ -67,9 +69,11 @@
   text-align: left;
   color: $deep-navy;
   margin-bottom: 0px;
+  text-decoration: none;
   &:hover {
     background: $light-blue;
     color: inherit;
+    text-decoration: underline;
     transition: $transition-default;
     cursor: pointer;
   }

--- a/_sass/rac/_layout.scss
+++ b/_sass/rac/_layout.scss
@@ -223,13 +223,14 @@ html {
     background-size: cover;
     margin-bottom: $gutters-default;
     margin-right: $gutters-default * 2;
+    text-decoration: none;
+    &:focus {
+      text-decoration: underline;
+    }
     @media screen and (min-width: $break-md) {
       @include grid-column(6);
       margin-right: 0;
       padding: 27px 64px 40px 25px;
-    }
-    &:hover {
-      text-decoration: none;
     }
     h2 {
       font-family: $sans-serif-stack;
@@ -279,6 +280,13 @@ html {
       box-sizing: border-box;
       margin-bottom: 54px;
     }
+  }
+  a {
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+
   }
   img {
     height: 60px;
@@ -431,8 +439,9 @@ section {
   box-sizing: border-box;
   padding: 18px 20px;
   width: 100%;
-  &:hover {
-    text-decoration: none;
+  text-decoration: none;
+  &:focus {
+    text-decoration: underline;
   }
   @media screen and (min-width: $break-md) {
     @include grid-column(6);

--- a/_sass/rac/_side-nav.scss
+++ b/_sass/rac/_side-nav.scss
@@ -37,13 +37,12 @@
       color: $pure-white;
       font-size: 14px;
       line-height: 17px;
+      text-decoration: none;
       &:focus {
         outline: 2px solid $pure-white;
-        text-decoration: none;
       }
       &:hover {
         cursor: pointer;
-        text-decoration: none;
       }
       &:not(:last-child) {
         margin-bottom: 20px;

--- a/_sass/rac/_typography.scss
+++ b/_sass/rac/_typography.scss
@@ -85,15 +85,15 @@ h4 {
 }
 
 a {
-  font-weight: 700;
+  font-weight: $font-weight-normal;
   color: $burnt-orange;
-  text-decoration: none;
+  text-decoration: underline;
   transition: $transition-default;
   &:focus {
     text-decoration: underline;
   }
   &:hover {
-    text-decoration: underline;
+    text-decoration: none;
     color: $red-orange;
     cursor: pointer;
   }
@@ -132,9 +132,9 @@ small {
   margin-bottom: 10px;
   a {
     text-decoration: underline;
-    font-weight: $font-weight-normal;
     &:hover {
       color: $burnt-orange;
+      text-decoration: none;
       transition: $transition-default;
     }
   }

--- a/about-us/accessibility-statement.md
+++ b/about-us/accessibility-statement.md
@@ -1,0 +1,80 @@
+---
+layout: page-sidebar
+title: Accessibility Statement
+permalink: /about-us/accessibility/
+---
+
+## Commitment to Accessibility
+The Rockefeller Archive Center (RAC) is committed to providing broad and equitable access to our collections, facilities, programs, services, and websites for people with disabilities in ways that are welcoming and inclusive and that support a right to privacy and self-determination.
+
+The purpose of this statement is to provide information for all visitors, including researchers, about the accessibility of our physical and digital spaces, including possible barriers and available accommodations.
+
+## Physical Space
+The RAC is housed in two multi-story buildings constructed out of stone, concrete, and steel as a private home for a member of the Rockefeller family in the 1960s. There have been various upgrades to improve access since the original construction, but there are some inherent architectural challenges for which we strive to provide accommodations as we continue to make accessibility a priority. The RAC is committed to ensuring to the greatest extent possible that any alterations and new construction will meet the accessibility standards set by the [Americans with Disabilities Act (ADA)](https://www.dol.gov/general/topic/disability/ada) while also respecting the historical origins of the buildings and the challenges presented by its construction.
+
+The main gate-controlled entrance links to drives that access both buildings. The property itself is approximately 24 acres, most of which consist of landscaped and wooded areas. The two main buildings, called the “Main House” and “Carriage House,” are near the center and high point of the property. Spaces accessed by the public include two Reading Rooms, a Researcher Lounge, conference and other meeting rooms, bathrooms, and (when escorted by staff) the RAC Preservation Lab and archival vaults.
+
+Visitors are always welcome to [contact us](#contact-us) with any questions.
+
+### Parking
+
+- Accessible parking is available at the front circle adjacent to the Main House entrance.
+- There is a paved road from the parking location leading to the Carriage House.
+
+### Entrances
+
+- The Main House front circle entrance includes two steps leading to a double door which opens manually with a round doorknob. The double door has a clear opening of 53”. A portable ADA-complaint ramp is available to enable access. [Advance notice]((#contact-us)) is requested for ramp installation.
+- The Carriage House entrance consists of a stone walkway with a small step at the start of the walkway and an additional step and raised sill at the entrance door. The entrance door has a narrow opening of 30 ½”.
+
+### Reading Rooms and Other Public Spaces 
+
+The Reading Rooms for researchers are located on the 2nd floor, up one flight of stairs from the Main House entrance and accessible by [elevator](#elevators).
+- Reading Room desks have a height of 30”. Adjustable-height desks are available in the Reading Rooms and can be provided [upon request](#contact-us).
+- The Researcher Lounge is located on the 1st floor and is used primarily as a break and lunchroom. The Researcher Lounge can be difficult to maneuver in a wheelchair because it is a small space with a narrow door opening of 31 ½”.
+- The Conference Room is often used to host groups of visitors; it is located on the 1st floor with two steps down to the entrance. A portable ramp is available to enable access; [advance notice](#contact-us) is requested for installation.
+- There is an accessible bathroom on the 1st floor in the foyer next to the Main House front entrance. 
+
+### Elevators 
+
+- The elevators do not conform to all ADA requirements. They may be too small for some wheelchairs and mobility scooters, buttons and doorknobs may be too high to reach while seated, and the entrances include manual doors with round doorknobs. The carriages do not contain handrails, braille, or audible signals of floors passing/stops.
+- The Main House has an elevator that visitors can use to access the basement level, the 1st floor, and 2nd floor. The door’s opening is 32”, and the cab dimensions are 38 ½” L x 53” W x 90” H.  The elevator is accessed with a round doorknob which is 35” from the floor and it contains an emergency call box.
+- The Carriage House has an elevator that visitors can use to access the 2nd floor. The door’s opening is 28”, and the cab dimensions are 40” L x 40” W x 80” H. The elevator is accessed with a round doorknob which is 38” from the floor and it contains an emergency call box.
+- The RAC provides a wheelchair that fits within the Main House elevator. [Advance notice is requested](#contact-us) so that it can be made available to visitors upon arrival.
+
+### Grounds
+
+- Access to the grounds is possible, but various areas are grassy fields, not level, or contain hills which limit access.
+- The back patio terrace is accessible through the front circle by crossing a grass lawn or through the dining room of the Main House. The dining room door has a very narrow opening of 23”. There is also a step at the door leading to a landing and then another step down to the terrace. 
+
+### Service Animals and Research Assistance
+
+- Service animals are welcome.
+- Personal care assistants and research assistants are welcome. For research appointments, we ask that researchers provide advance notice when scheduling their visit if additional people will be joining them in the Reading Room.
+- Researchers are welcome to bring assistive equipment such as headphones or other listening receivers and magnifying equipment to read documents.
+
+## Digital Space
+
+The RAC maintains multiple public websites to facilitate the discovery of and access to its archival collections, engage with research and educational materials related to the collections, share documentation and perspectives about its work, and enable donor organizations to transfer digital records. We target the [Web Content Accessibility Guidelines (WCAG) 2.1](https://www.w3.org/WAI/standards-guidelines/wcag/) Level AA, which explain how to make web content accessible to people with a wide range of disabilities, as our minimum standard.
+
+### Known Issues
+
+- Website color contrast: some website color combinations do not yet meet the WCAG 2.x AA contrast standards and are under review.
+- There is a lack of screen reader access to archival records in the [DIMES](https://dimes.rockarch.org/) document viewer. To access content, users can download the PDF. We use automated OCR (optical character recognition) for PDFs, but this can include errors, particularly for hand-written documents.
+- Much of the archival audiovisual content lacks captions, transcriptions, or audio description.
+- Microfilm software in Reading Rooms is not accessible with screen readers or other assistive technology and does not support keyboard-only navigation.
+
+### Technical Specifications
+
+The RAC relies on the following technologies to work with the specific combination of web browser and assistive technology or plugins installed on users’ computers.
+- HTML
+- CSS
+- [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/)
+- JavaScript
+- SVG
+
+## Contact Us
+
+How can we be more accessible? Please send an e-mail to [archive@rockarch.org](mailto:archive@rockarch.org) or call 914-366-6300 with feedback or with requests for more information or accommodation.
+
+Statement reviewed annually by [RAC Operations](/about-us/board-and-staff#operations).
+Last updated: October 11, 2022

--- a/about-us/accessibility-statement.md
+++ b/about-us/accessibility-statement.md
@@ -23,10 +23,10 @@ Visitors are always welcome to [contact us](#contact-us) with any questions.
 
 ### Entrances
 
-- The Main House front circle entrance includes two steps leading to a double door which opens manually with a round doorknob. The double door has a clear opening of 53”. A portable ADA-complaint ramp is available to enable access. [Advance notice]((#contact-us)) is requested for ramp installation.
+- The Main House front circle entrance includes two steps leading to a double door which opens manually with a round doorknob. The double door has a clear opening of 53”. A portable ADA-complaint ramp is available to enable access. [Advance notice](#contact-us) is requested for ramp installation.
 - The Carriage House entrance consists of a stone walkway with a small step at the start of the walkway and an additional step and raised sill at the entrance door. The entrance door has a narrow opening of 30 ½”.
 
-### Reading Rooms and Other Public Spaces 
+### Reading Rooms and Other Public Spaces
 
 The Reading Rooms for researchers are located on the 2nd floor, up one flight of stairs from the Main House entrance and accessible by [elevator](#elevators).
 - Reading Room desks have a height of 30”. Adjustable-height desks are available in the Reading Rooms and can be provided [upon request](#contact-us).
@@ -34,7 +34,7 @@ The Reading Rooms for researchers are located on the 2nd floor, up one flight of
 - The Conference Room is often used to host groups of visitors; it is located on the 1st floor with two steps down to the entrance. A portable ramp is available to enable access; [advance notice](#contact-us) is requested for installation.
 - There is an accessible bathroom on the 1st floor in the foyer next to the Main House front entrance. 
 
-### Elevators 
+### Elevators
 
 - The elevators do not conform to all ADA requirements. They may be too small for some wheelchairs and mobility scooters, buttons and doorknobs may be too high to reach while seated, and the entrances include manual doors with round doorknobs. The carriages do not contain handrails, braille, or audible signals of floors passing/stops.
 - The Main House has an elevator that visitors can use to access the basement level, the 1st floor, and 2nd floor. The door’s opening is 32”, and the cab dimensions are 38 ½” L x 53” W x 90” H.  The elevator is accessed with a round doorknob which is 35” from the floor and it contains an emergency call box.
@@ -76,5 +76,5 @@ The RAC relies on the following technologies to work with the specific combinati
 
 How can we be more accessible? Please send an e-mail to [archive@rockarch.org](mailto:archive@rockarch.org) or call 914-366-6300 with feedback or with requests for more information or accommodation.
 
-Statement reviewed annually by [RAC Operations](/about-us/board-and-staff#operations).
+Statement reviewed annually by RAC Operations.  
 Last updated: October 11, 2022

--- a/about-us/accessibility-statement.md
+++ b/about-us/accessibility-statement.md
@@ -23,7 +23,7 @@ Visitors are always welcome to [contact us](#contact-us) with any questions.
 
 ### Entrances
 
-- The Main House front circle entrance includes two steps leading to a double door which opens manually with a round doorknob. The double door has a clear opening of 53”. A portable ADA-complaint ramp is available to enable access. [Advance notice](#contact-us) is requested for ramp installation.
+- The Main House front circle entrance includes two steps leading to a double door which opens manually with a round doorknob. The double door has a clear opening of 53”. A portable ADA-complaint ramp is available to enable access. [Advance notice is requested](#contact-us) for ramp installation.
 - The Carriage House entrance consists of a stone walkway with a small step at the start of the walkway and an additional step and raised sill at the entrance door. The entrance door has a narrow opening of 30 ½”.
 
 ### Reading Rooms and Other Public Spaces
@@ -31,12 +31,12 @@ Visitors are always welcome to [contact us](#contact-us) with any questions.
 The Reading Rooms for researchers are located on the 2nd floor, up one flight of stairs from the Main House entrance and accessible by [elevator](#elevators).
 - Reading Room desks have a height of 30”. Adjustable-height desks are available in the Reading Rooms and can be provided [upon request](#contact-us).
 - The Researcher Lounge is located on the 1st floor and is used primarily as a break and lunchroom. The Researcher Lounge can be difficult to maneuver in a wheelchair because it is a small space with a narrow door opening of 31 ½”.
-- The Conference Room is often used to host groups of visitors; it is located on the 1st floor with two steps down to the entrance. A portable ramp is available to enable access; [advance notice](#contact-us) is requested for installation.
+- The Conference Room is often used to host groups of visitors; it is located on the 1st floor with two steps down to the entrance. A portable ramp is available to enable access; [advance notice is requested](#contact-us) for installation.
 - There is an accessible bathroom on the 1st floor in the foyer next to the Main House front entrance. 
 
 ### Elevators
 
-- The elevators do not conform to all ADA requirements. They may be too small for some wheelchairs and mobility scooters, buttons and doorknobs may be too high to reach while seated, and the entrances include manual doors with round doorknobs. The carriages do not contain handrails, braille, or audible signals of floors passing/stops.
+The elevators do not conform to all ADA requirements. They may be too small for some wheelchairs and mobility scooters, buttons and doorknobs may be too high to reach while seated, and the entrances include manual doors with round doorknobs. The carriages do not contain handrails, braille, or audible signals of floors passing/stops.
 - The Main House has an elevator that visitors can use to access the basement level, the 1st floor, and 2nd floor. The door’s opening is 32”, and the cab dimensions are 38 ½” L x 53” W x 90” H.  The elevator is accessed with a round doorknob which is 35” from the floor and it contains an emergency call box.
 - The Carriage House has an elevator that visitors can use to access the 2nd floor. The door’s opening is 28”, and the cab dimensions are 40” L x 40” W x 80” H. The elevator is accessed with a round doorknob which is 38” from the floor and it contains an emergency call box.
 - The RAC provides a wheelchair that fits within the Main House elevator. [Advance notice is requested](#contact-us) so that it can be made available to visitors upon arrival.
@@ -71,6 +71,19 @@ The RAC relies on the following technologies to work with the specific combinati
 - [WAI-ARIA](https://www.w3.org/WAI/standards-guidelines/aria/)
 - JavaScript
 - SVG
+
+### Assistive Technology and Browser Compatibility
+
+The RAC tests its websites primarily in Chrome, Firefox, and Safari with [NVDA](https://www.nvaccess.org/download/) and [VoiceOver](https://support.apple.com/guide/voiceover/welcome/mac), with plans for a more comprehensive audit including testing with [JAWS](https://www.freedomscientific.com/products/software/jaws/).
+
+### RAC Digital Accessibility Tools
+
+- Use semantic HTML, skip links, landmark areas, descriptive page titles, ordered headings, and alternative descriptions for non-text elements to support assistive technology.
+- Enable preferences for a reduced animation experience.
+- Develop open-source systems to allow for public review and requests for modification of the code.
+- Provide staff training to support accessible website design, development, and maintenance.
+- Run automated and manual checks to test for accessibility issues.
+- Standardize [website styles](https://styles.rockarch.org/) across our sites to enable a consistent user experience.
 
 ## Contact Us
 

--- a/collections/access-and-request-materials/index.md
+++ b/collections/access-and-request-materials/index.md
@@ -27,8 +27,7 @@ Contact the RAC Reference team at [archive@rockarch.org](mailto:archive@rockarch
 
 ## How to Research at the RAC
 
-Anyone can conduct research at the RAC. If we have archival materials that can be
-useful to your research topic, you are welcome here.
+Anyone can conduct research at the RAC. If we have archival materials that can be useful to your research topic, you are welcome here. The [RAC Accessibility Statement](/about-us/accessibility/) includes more details about access and how to request accommodations.
 
 Because of limited seating capacity, researchers need an appointment in order to
 conduct in-person research in the RAC’s Reading Room. Contact the RAC Reference
@@ -95,6 +94,9 @@ and procedures and get you ready to work in the reading room, and if you would
 like, we can chat further about your project and the archival collections.
 
 ## What You Can Expect When You Get Here
+
+For more details about the accessibility of the physical space, see our
+[Accessibility Statement](/about-us/accessibility).
 
 When you arrive on the first day of your scheduled research visit, you will be
 greeted and brought up to the reading room.


### PR DESCRIPTION
Fixes #172 

- Adds text of statement
- Adds link to statement in footer
- Adds links to statement in Access and Request Materials page (we'll likely want further review of this text change from others)

This also updates link styles to underline link text in paragraphs. This will be a change we'll implement with the style library, but it's one of those things that's a very visible and often-cited measure of digital accessibility, so it might be a nice improvement to slide in right away with the statement.