### PR TITLE
Replace links to Project Electron with API Docs

### DIFF
--- a/about-us/program-areas.md
+++ b/about-us/program-areas.md
@@ -24,7 +24,7 @@ Processing, Reference, and Digital Strategies.
 
 <a href="https://blog.rockarch.org" class="rac-blue-button">Bits &amp; Bytes</a>
 <a href="https://docs.rockarch.org" class="rac-blue-button">Archive Documentation</a>
-<a href="https://projectelectron.rockarch.org" class="rac-blue-button">Project Electron</a>
+<a href="https://docs.rockarch.org/argo-docs/" class="rac-blue-button">Collections Data API</a>
 
 ### Records and Information Management Program
 

--- a/about-us/program-areas.md
+++ b/about-us/program-areas.md
@@ -24,7 +24,6 @@ Processing, Reference, and Digital Strategies.
 
 <a href="https://blog.rockarch.org" class="rac-blue-button">Bits &amp; Bytes</a>
 <a href="https://docs.rockarch.org" class="rac-blue-button">Archive Documentation</a>
-<a href="https://docs.rockarch.org/argo-docs/" class="rac-blue-button">Collections Data API</a>
 
 ### Records and Information Management Program
 

--- a/collections/access-and-request-materials/index.md
+++ b/collections/access-and-request-materials/index.md
@@ -6,6 +6,7 @@ sidebar:
   - ["https://raccess.rockarch.org", Log into/Create a new RACcess account, arrow_forward]
   - ["https://dimes.rockarch.org", Search collections at DIMES, arrow_forward]
   - ["https://library.rockarch.org", Search library materials, arrow_forward]
+  - ["https://docs.rockarch.org/argo-docs/", Access collections API, arrow_forward</>]
   - ["mailto:archive@rockarch.org", Schedule a Research Visit, email]
 ---
 

--- a/collections/access-and-request-materials/index.md
+++ b/collections/access-and-request-materials/index.md
@@ -3,11 +3,11 @@ layout: page-sidebar
 title: Access & Request Materials
 permalink: /collections/access-and-request-materials/
 sidebar:
+  - ["mailto:archive@rockarch.org", Schedule a Research Visit, email]
   - ["https://raccess.rockarch.org", Log into/Create a new RACcess account, arrow_forward]
   - ["https://dimes.rockarch.org", Search collections at DIMES, arrow_forward]
+  - ["https://docs.rockarch.org/argo-docs/", Access collections API, arrow_forward]
   - ["https://library.rockarch.org", Search library materials, arrow_forward]
-  - ["https://docs.rockarch.org/argo-docs/", Access collections API, arrow_forward</>]
-  - ["mailto:archive@rockarch.org", Schedule a Research Visit, email]
 ---
 
 <div class="alert">

--- a/index.html
+++ b/index.html
@@ -102,8 +102,8 @@ layout: page-home
           <p class="small">A bibliography of works based on research at the RAC.</p>
         </div>
         <div class="link-wrapper">
-          <h3 class="link no-border"><a href="https://projectelectron.rockarch.org">Project Electron</a></h3>
-          <p class="small">Our digital records infrastructure project.</p>
+          <h3 class="link no-border"><a href="https://docs.rockarch.org/argo-docs/">Collections Data API</a></h3>
+          <p class="small">A public API to access our archival collections data.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Because we are decommissioning the Project Electron website, we need to remove/replace the links to the site on the rockarch.org site. A common issue cited by people who use or want to use APIs from cultural heritage sites is that they are hard to find or under-documented. Replacing the Project Electron links with links to our API documentation would raise the API's profile on the site, since currently the only reference to it is in a footer link.

Links would be replaced in these two locations:

1. Removed on the [Program Areas](https://rockarch.org/about-us/program-areas/) page and added to the [Access and Request Materials](https://rockarch.org/collections/access-and-request-materials/) page:

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/15254041/230659262-0eba16f3-5633-47da-b3d3-0220896fe4ba.png">


2. In the Quick Links section of [the homepage](https://rockarch.org/).

<img width="1185" alt="image" src="https://user-images.githubusercontent.com/15254041/229830107-9fee2db0-0b61-47a4-908a-85a39cade2e1.png">
