### PR TITLE
Update Research Stipend page for 2024 cycle

### DIFF
--- a/about-us/board-and-staff.md
+++ b/about-us/board-and-staff.md
@@ -116,6 +116,9 @@ University Archivist, Harvard University Archives
 **Renee Pappous**, Archivist, Access  
 (914) 366-6355  
 
+**Tyler Perry**, Reading Room Assistant, Access  
+(914) 366-6329
+
 **Brent Phillips**, Audiovisual Archivist, Collections Management  
 (914) 366-6324
 

--- a/collections/research-stipends.md
+++ b/collections/research-stipends.md
@@ -19,7 +19,7 @@ Applications are evaluated by an independent committee that considers an applica
 
 Please use our [online form](https://forms.office.com/r/MvSfhUepLG) to apply for a research stipend. Please note that beginning this year, applicants are no longer required to contact an archivist in advance to be eligible to apply. However, RAC Access archivists are available to answer questions by writing to [archive@rockarch.org](mailto:archive@rockarch.org). Applicants should also consult our online collections discovery system, [DIMES](https://dimes.rockarch.org/) to identify relevant research materials.
 
-The online application form will ask for information about your proposed research project and how research in the RAC collections would support it. Applications should be prepared to write a brief narrative describing their research project, including a description of what they seek to find in the proposed materials.
+The online application form will ask for information about your proposed research project and how research in the RAC collections would support it. Applicants should be prepared to write a brief narrative describing their research project, including a description of what they seek to find in the proposed materials.
 
 The application form also requests the name and email address of at least one and up to two references who can recommend you for a research stipend. After the application is submitted, we will contact the references directly with information about how to submit their recommendation.
 

--- a/collections/research-stipends.md
+++ b/collections/research-stipends.md
@@ -6,7 +6,7 @@ permalink: /collections/research-stipends/
 
 <div class="alert">
 The application for the 2024 Research Stipend is now open! The deadline to submit applications is Friday, November 3, at 11:59pm Eastern Time. Learn more information about the application process and other Rockefeller Archive Center (RAC) stipend programs below. To apply, please use our online form:
-<a href="https://forms.office.com/r/MvSfhUepLG">2024 Research Stipend Application</a>
+<a href="https://forms.office.com/r/MvSfhUepLG">2024 Research Stipend Application</a>.
 </div>
 
 ## About the RAC Stipend Program

--- a/collections/research-stipends.md
+++ b/collections/research-stipends.md
@@ -6,7 +6,7 @@ permalink: /collections/research-stipends/
 
 <div class="alert">
 The application for the 2024 Research Stipend is now open! The deadline to submit applications is Friday, November 3, at 11:59pm Eastern Time. Learn more information about the application process and other Rockefeller Archive Center (RAC) stipend programs below. To apply, please use our online form:
-[2024 Research Stipend Application](https://forms.office.com/r/MvSfhUepLG)
+<a href="https://forms.office.com/r/MvSfhUepLG">2024 Research Stipend Application</a>
 </div>
 
 ## About the RAC Stipend Program

--- a/collections/research-stipends.md
+++ b/collections/research-stipends.md
@@ -17,7 +17,7 @@ Applications are evaluated by an independent committee that considers an applica
 
 ## How to Apply for an RAC Research Stipend
 
-Please use our [online form](https://forms.office.com/r/MvSfhUepLG) to apply for a research stipend. Please note that beginning this year, applicants are no longer required to contact an archivist in advance to be eligible to apply. However, RAC Access archivists are available to answer questions by writing to [archive@rockarch.org](mailto:archive@rockarch.org). Applicants should also consult our online collections discovery system, [DIMES](dimes.rockarch.org) to identify relevant research materials.
+Please use our [online form](https://forms.office.com/r/MvSfhUepLG) to apply for a research stipend. Please note that beginning this year, applicants are no longer required to contact an archivist in advance to be eligible to apply. However, RAC Access archivists are available to answer questions by writing to [archive@rockarch.org](mailto:archive@rockarch.org). Applicants should also consult our online collections discovery system, [DIMES](https://dimes.rockarch.org/) to identify relevant research materials.
 
 The online application form will ask for information about your proposed research project and how research in the RAC collections would support it. Applications should be prepared to write a brief narrative describing their research project, including a description of what they seek to find in the proposed materials.
 

--- a/collections/research-stipends.md
+++ b/collections/research-stipends.md
@@ -5,28 +5,49 @@ permalink: /collections/research-stipends/
 ---
 
 <div class="alert">
-The current Research Stipend application cycle is closed. Please check back in summer 2023 for information about applying for a 2024 stipend. And please scroll down to read about our other stipend programs, which have different deadlines than the annual Research Stipend.
+The application for the 2024 Research Stipend is now open! The deadline to submit applications is Friday, November 3, at 11:59pm Eastern Time. Learn more information about the application process and other Rockefeller Archive Center (RAC) stipend programs below. To apply, please use our online form:
+[2024 Research Stipend Application](https://forms.office.com/r/MvSfhUepLG)
 </div>
 
 ## About the RAC Stipend Program
 
-The Rockefeller Archive Center offers a competitive research stipend program that provides individuals (not institutions) up to $5,000 for reimbursement of travel and accommodation expenses.  The stipend can only be used to facilitate research at the RAC, not for research at other archival repositories or for tuition support.
+The RAC offers a competitive research stipend program that provides individuals (not institutions) up to $5,000 for reimbursement of travel and accommodation expenses. The stipend can only be used to support research time at the RAC, not for research at other archival repositories or for tuition.
 
-Applications are reviewed by an independent committee that considers an applicant’s topic and the availability of relevant archival materials at the RAC. Anyone can apply for a research stipend, regardless of country of origin. Please be aware that certain U.S Government requirements may apply to non-U.S. citizens.
+Applications are evaluated by an independent committee that considers an applicant’s project and the availability of relevant archival materials at the RAC. Anyone can apply for a research stipend, from any country of origin, field or discipline, and at any level of professional background. 
+
+## How to Apply for an RAC Research Stipend
+
+Please use our [online form](https://forms.office.com/r/MvSfhUepLG) to apply for a research stipend. Please note that beginning this year, applicants are no longer required to contact an archivist in advance to be eligible to apply. However, RAC Access archivists are available to answer questions by writing to [archive@rockarch.org](mailto:archive@rockarch.org). Applicants should also consult our online collections discovery system, [DIMES](dimes.rockarch.org) to identify relevant research materials.
+
+The online application form will ask for information about your proposed research project and how research in the RAC collections would support it. Applications should be prepared to write a brief narrative describing their research project, including a description of what they seek to find in the proposed materials.
+
+The application form also requests the name and email address of at least one and up to two references who can recommend you for a research stipend. After the application is submitted, we will contact the references directly with information about how to submit their recommendation.
+
+The deadline to submit the application for the 2024 Research Stipend is **Friday, November 3, 2023 11:59pm Eastern Time.**
+
+Awards will be announced via email in March 2024.
+
+## After Receiving an RAC Research Stipend
+
+Stipend recipients have from April 1, 2024 through June 30, 2025 to complete their research.
+
+All stipend recipients are required to submit a report on the research conducted at the RAC within two months of completing their visit. View the full library of published RAC Research Reports in our [online library](https://rockarch.issuelab.org).
+
+To be reimbursed for travel and accommodation expenses, stipend recipients must provide receipts following completion of the research visit. Digital versions of receipts are accepted.
 
 ## Related Stipend Programs
 
 ## The Commonwealth Fund’s Paul Engel Memorial Award Program
 
-This award honors the memory of Paul Engel, director and curator of the Fund’s Harkness House from 2003 until his death in 2022. It provides individuals with up to $5,000 to reimburse travel and accommodation expenses for short-term research in the RAC’s Commonwealth Fund collections.
+This award honors the memory of Paul Engel, director and curator of the Fund’s Harkness House from 2003 until his death in 2022. It provides individuals with up to $5,000 to reimburse travel and accommodation expenses for short-term research in the RAC’s Commonwealth Fund collections.
 
-Paul maintained Harkness House, the Fund’s headquarters, as a welcoming space for staff and visitors. Holding bachelor’s degrees in fine arts and architecture from the Rhode Island School of Design and a master’s degree in architecture from Harvard University, Paul’s passions for interior design, architecture, historic preservation, and history were evident in his care for the building and his detailed knowledge of Harkness family history. This award aims to encourage the pursuit of knowledge about the foundation to which Paul devoted a large portion of his career.
+Paul maintained Harkness House, the Fund’s headquarters, as a welcoming space for staff and visitors. Holding bachelor’s degrees in fine arts and architecture from the Rhode Island School of Design and a master’s degree in architecture from Harvard University, Paul’s passions for interior design, architecture, historic preservation, and history were evident in his care for the building and his detailed knowledge of Harkness family history. This award aims to encourage the pursuit of knowledge about the foundation to which Paul devoted a large portion of his career.
 
-Researchers at any level, from any country, working in any field for which the Fund’s collections are relevant are eligible to apply. Potential applicants should first contact the RAC at [archive@rockarch.org](mailto:archive@rockarch.org) with a description of their proposed research and indicate that their inquiry is for the purposes of applying for this award. RAC staff will help to identify and describe relevant archival materials and assist the applicant in estimating the time necessary to complete their research.
+Researchers at any level, from any country, working in any field for which the Fund’s collections are relevant are eligible to apply. Potential applicants should first contact the RAC at [archive@rockarch.org](mailto:archive@rockarch.org) with a description of their proposed research and indicate that their inquiry is for the purposes of applying for this award. RAC staff will help to identify and describe relevant archival materials and assist the applicant in estimating the time necessary to complete their research.
 
-Applicants may then submit a formal request for consideration at [RACstipend@rockarch.org](mailto:RACstipend@rockarch.org). This should include a description of the project, the materials to be studied, expected outcomes or products of the research, and two letters of recommendation. Submissions are welcome at any time. Award decisions will be made within one month of the receipt of all application materials. Recipients must commence their research at the RAC within one year of being notified of the award.
+Applicants may then submit a formal request for consideration at [RACstipend@rockarch.org](mailto:RACstipend@rockarch.org). This should include a description of the project, the materials to be studied, expected outcomes or products of the research, and two letters of recommendation. Submissions are welcome at any time. Award decisions will be made within one month of the receipt of all application materials. Recipients must commence their research at the RAC within one year of being notified of the award.
 
-The Fund has established the Paul Engel Memorial Award Program with an initial grant of $25,000. The RAC will accept additional donations in support of the program. If you would like to make a gift in honor of Paul, please contact [RACstipend@rockarch.org](mailto:RACstipend@rockarch.org) for more information. 
+The Fund has established the Paul Engel Memorial Award Program with an initial grant of $25,000. The RAC will accept additional donations in support of the program. If you would like to make a gift in honor of Paul, please contact [RACstipend@rockarch.org](mailto:RACstipend@rockarch.org) for more information. 
 
 ## Special Stipend to Support Research in the Paul Ehrlich Collection
 
@@ -42,5 +63,4 @@ Stipend recipients must commence their research at the RAC within one year of be
 
 ## Stipend Through the Consortium for History of Science, Technology, and Medicine
 
-The Rockefeller Archive Center is part of the [Consortium for History of Science, Technology, and Medicine](https://www.chstm.org/), which has a [fellowship program](https://www.chstm.org/fellowships/chstm-fellowships)
-offering support for research across the scholarly collections of the consortium. Please see the Consortium’s website for more details.  
+The Rockefeller Archive Center is part of the [Consortium for History of Science, Technology, and Medicine](https://www.chstm.org/), which has a [fellowship program](https://www.chstm.org/fellowships/chstm-fellowships) offering support for research across the scholarly collections of the consortium. Please see the Consortium’s website for more details.  


### PR DESCRIPTION
Launching the 2024 cycle with updated text and link to new application form.

Also adds new staff member to staff directory.